### PR TITLE
Kafka Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# teraslice_kafka_reader
-Teraslice reader from processing data from kafka topics.
+# Description
+
+Teraslice reader for processing data from kafka topics.
+
+# Output
+
+An array of records from Kafka. Array may be up to `size` in length. No additional processing is done on the records.
+
+# Parameters
+
+| Name | Description | Default | Required |
+| ---- | ----------- | ------- | -------- |
+| topic | Name of the Kafka topic to process |  | Y |
+| group | Name of the Kafka consumer group | | Y |
+| connection | The Kafka consumer connection to use | | Y |
+| size | How many records to read before a slice is considered complete | 10000 | N |
+| wait | How long to wait for a full chunk of data to be available. Specified in milliseconds. | 10000 | N |
+
+
+# Job configuration example
+
+This example reads from a topic `testing-topic` as part of the consumer group `testing-group` and outputs the result to stdout. It will wait 10 seconds per slice for up to 1000 records to be produced.
+
+```
+{
+  "name": "Simple test",
+  "lifecycle": "persistent",
+  "workers": 1,
+  "operations": [
+    {
+      "_op": "teraslice_kafka_reader",
+      "size": 1000,
+      "topic": "testing-topic",
+      "group": "testing-group"
+    },
+    {
+      "_op": "stdout"
+    }
+  ]
+}
+```
+
+# Notes
+
+ * This reader is primarily intended for persisent jobs. Better handling of once jobs may come in the future.
+ * The reader will wait `wait` milliseconds for data to be produced before considering the slice complete. If no data shows up within that window then an empty slice will be produced. On a persistent job the next iteration will start the same process again and it will continue to process the queue in the same manner until the job is stopped.
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,143 @@
+'use strict';
+
+var Promise = require("bluebird");
+var op = 'kafka_simple_reader';
+
+function newReader(context, opConfig, jobConfig) {
+    // TODO: this will move out into a connector
+    var Kafka = require("node-rdkafka");
+    var consumer_ready = false;
+    var subscribed = false;
+    var consumer;
+
+    return function(partition, logger) {
+console.log("Parition: " + partition);
+        if (! consumer_ready) {
+            consumer = new Kafka.KafkaConsumer({
+                'group.id': opConfig.group,
+                'metadata.broker.list': 'localhost:9092'
+            }, {
+                // TODO: we'll want to expose some of these settings
+                "auto.offset.reset": "smallest"
+            });
+
+            // TODO: errors and diconnects should set consumer_ready false
+
+            consumer.connect();
+
+            consumer.on('ready', function() {
+                consumer_ready = true;
+
+                logger.info("Consumer ready");
+            });
+        }
+
+        // We have to wait for the consumer to be ready. After the
+        // first slice this usually isn't an issue.
+
+        var subscriber = setInterval(function() {
+            if (consumer_ready && ! subscribed) {
+                logger.info("Subscribing to topic " + opConfig.topic);
+                clearInterval(subscriber);
+                consumer.subscribe([opConfig.topic]);
+                subscribed = true;
+            }
+        }, 10);
+
+        return new Promise(function(resolve, reject) {
+            var slice = [];
+            var iteration_start = Date.now();
+
+            function completeSlice() {
+
+                clearInterval(consuming);
+
+                //consumer.unsubscribe([opConfig.topic]);
+                consumer.removeListener('data', receiveData);
+                consumer.removeListener('error', error);
+
+                logger.info("Resolving with " + slice.length + " results.");
+
+                resolve(slice);
+            }
+
+            function receiveData(data) {
+                slice.push(data.value);
+
+                //console.log(data.value.toString());
+
+                if (slice.length >= opConfig.size) {
+                    completeSlice();
+                }
+            }
+
+            function error(err) {
+                logger.error(err);
+                reject(err);
+            }
+
+            var consuming = setInterval(function() {
+                if (subscribed) {
+                    if (((Date.now() - iteration_start) > opConfig.wait) || (slice.length >= opConfig.size)) {
+                        completeSlice();
+                    }
+                    else {
+                        consumer.consume(opConfig.size - slice.length);
+                    }
+                }
+            }, 1000)
+
+            // This is going to have an issue that data will still be coming in
+            // while the chunk is being processed.
+            consumer.on('data', receiveData);
+
+            consumer.on('error', error);
+        });
+    }
+}
+
+function newSlicer(context, job, retryData, slicerAnalytics, logger) {
+    // The slicer actually has no work to do here.
+    return Promise.resolve([function() {
+        return new Promise(function(resolve, reject) {
+            // We're using a timeout here to slow down the rate that slices
+            // are created otherwise it swamps the queue on startup. The
+            // value returned is meaningless but we still need something.
+            setTimeout(function() {
+                resolve(1);
+            }, 100)
+        });
+    }]);
+}
+
+function schema(){
+    return {
+        topic: {
+            doc: 'Name of the Kafka topic to process',
+            default: '',
+            format: 'required_String'
+        },
+        group: {
+            doc: 'Name of the Kafka consumer group',
+            default: '',
+            format: 'required_String'
+        },
+        size: {
+            doc: 'How many records to read before a slice is considered complete.',
+            default: 10,
+            format: Number
+        },
+        wait: {
+            doc: 'How long to wait for a full chunk of data to be available. Specified in milliseconds.',
+            default: 1000,
+            format: Number
+        }
+    };
+}
+
+module.exports = {
+    newReader: newReader,
+    newSlicer: newSlicer,
+    schema: schema,
+    parallelSlicers: false
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "teraslice_kafka_reader",
+  "version": "0.0.1",
+  "description": "Teraslice reader to process data stored in kafka topics",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/terascope/teraslice_kafka_reader.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/terascope/teraslice_kafka_reader/issues"
+  },
+  "homepage": "https://github.com/terascope/teraslice_kafka_reader#readme",
+  "dependencies": {
+    "bluebird": "^3.5.0",
+    "node-rdkafka": "^0.10.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,5 @@
   },
   "homepage": "https://github.com/terascope/teraslice_kafka_reader#readme",
   "dependencies": {
-    "bluebird": "^3.5.0",
-    "node-rdkafka": "^0.10.2"
   }
 }


### PR DESCRIPTION
Initial implementation still very much a work in progress.

Connection logic needs to move into a terafoundation connector.

If this can read a full `size` worth of results it will complete the slice. Otherwise it will automatically checkpoint the slice every `wait` ms even if there are 0 results. 

The `wait` time and `size` set in the configuration appears very finicky. Still trying to understand what's going on. Setting a longer `wait` time results in elasticsearch errors from the worker when trying to save state.

```
    {
      "_op": "teraslice_kafka_reader",
      "size": 1000,
      "topic": "testing2",
      "group": "testing-group",
      "wait": 10000
    },
```